### PR TITLE
fix: return "agreeabilityTypeId" for terms

### DIFF
--- a/src/services/TermsOfUseService.js
+++ b/src/services/TermsOfUseService.js
@@ -91,7 +91,6 @@ function convertRawData (termsOfUse, throwError = true) {
   } else {
     delete termsOfUse.docusignTemplateId
   }
-  delete termsOfUse.agreeabilityTypeId
 
   return _.omitBy(termsOfUse, _.isNull)
 }


### PR DESCRIPTION
We have to return `agreeabilityTypeId` when we retrieve a single Terms record, so we can show the current value:

![image](https://user-images.githubusercontent.com/146016/93428456-279d7680-f8c8-11ea-9a71-ed9728779813.png)
